### PR TITLE
fix: sync with 0.0.2 on the marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ For issues and feature requests, please create an issue in the repository or con
 
 
 
+contact：evanchen@dify.ai

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: yevanchen
 name: markitdown


### PR DESCRIPTION
It seems that the latest data available on the marketplace is not in this repository, so I reflected it in here.

I only downloaded version 0.0.2 and overwrote the extracted files.

- https://marketplace.dify.ai/plugins/yevanchen/markitdown
- https://github.com/langgenius/dify-plugins/pull/137