### PR TITLE
fix: add feature-groups for markitdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dify_plugin
-markitdown
+markitdown[all]


### PR DESCRIPTION
This PR adds `[all]` feature-groups for markitdown to `requirements.txt`, to prevent errors during processing pptx, xlsx, etc.

Closes https://github.com/Yevanchen/markitdown-dify-plugin/issues/6, closes https://github.com/Yevanchen/markitdown-dify-plugin/issues/4